### PR TITLE
Adding round method

### DIFF
--- a/src/format/round.ts
+++ b/src/format/round.ts
@@ -1,0 +1,32 @@
+interface options {
+    nbDecimals?: number
+    nearestInteger?: number
+}
+
+interface mergedOptions {
+    nbDecimals: number
+    nearestInteger: number
+}
+
+export default function round(number: number, options: options = {}): number {
+    const mergedOptions: mergedOptions = {
+        nbDecimals: 0,
+        nearestInteger: 1,
+        ...options,
+    }
+
+    if (mergedOptions.nbDecimals > 0 && mergedOptions.nearestInteger > 1) {
+        throw new Error(
+            "You can't use nbDecimals and nearestInteger at the same time. Use just one option."
+        )
+    }
+
+    if (mergedOptions.nearestInteger === 1) {
+        return parseFloat(number.toFixed(mergedOptions.nbDecimals))
+    } else {
+        return (
+            Math.round(number / mergedOptions.nearestInteger) *
+            mergedOptions.nearestInteger
+        )
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import formatDate from "./format/formatDate.js"
 import formatNumber from "./format/formatNumber.js"
+import round from "./format/round.js"
 
-export { formatDate, formatNumber }
+export { formatDate, formatNumber, round }

--- a/test/format/round.test.ts
+++ b/test/format/round.test.ts
@@ -1,0 +1,37 @@
+import assert from "assert"
+import round from "../../src/format/round.js"
+
+describe("round", () => {
+    it("should keep an integer as integer", () => {
+        const rounded = round(1)
+        assert.strictEqual(rounded, 1)
+    })
+    it("should round 1.2 to 1", () => {
+        const rounded = round(1.2)
+        assert.strictEqual(rounded, 1)
+    })
+    it("should round 1.5 to 2", () => {
+        const rounded = round(1.5)
+        assert.strictEqual(rounded, 2)
+    })
+    it("should round 1.8 to 2", () => {
+        const rounded = round(1.8)
+        assert.strictEqual(rounded, 2)
+    })
+    it("should round 1.1234567 to 1.1", () => {
+        const rounded = round(1.1234567, { nbDecimals: 1 })
+        assert.strictEqual(rounded, 1.1)
+    })
+    it("should round 1.1234567 to 1.12346", () => {
+        const rounded = round(1.1234567, { nbDecimals: 5 })
+        assert.strictEqual(rounded, 1.12346)
+    })
+    it("should round 12345 to the closest 10", () => {
+        const rounded = round(12345, { nearestInteger: 10 })
+        assert.strictEqual(rounded, 12350)
+    })
+    it("should round 12345 to the closest 100", () => {
+        const rounded = round(12345, { nearestInteger: 100 })
+        assert.strictEqual(rounded, 12300)
+    })
+})


### PR DESCRIPTION
Two options:
- nbDecimals to round with a specific number of decimals
- nearestInteger to round to a specific base (for example, 123 round with base 10 would return 120).

Once merged, I would use this function in formatNumber to add an option to round while formatting a number.