### PR TITLE
formatNumber with options

### DIFF
--- a/test/format/formatNumber.test.ts
+++ b/test/format/formatNumber.test.ts
@@ -64,6 +64,25 @@ describe("formatNumber", () => {
         })
         assert.strictEqual(string, "-11,520")
     })
+    it("should return the number with prefix", () => {
+        const string = formatNumber(-11523, {
+            prefix: "$",
+        })
+        assert.strictEqual(string, "$-11,523")
+    })
+    it("should return the number with suffix", () => {
+        const string = formatNumber(35, {
+            suffix: " C",
+        })
+        assert.strictEqual(string, "35 C")
+    })
+    it("should return the number with a prefix and a suffix", () => {
+        const string = formatNumber(35, {
+            prefix: "Temp.: ",
+            suffix: " C",
+        })
+        assert.strictEqual(string, "Temp.: 35 C")
+    })
 
     // Radio-Canada style
 
@@ -137,5 +156,27 @@ describe("formatNumber", () => {
             style: "rc",
         })
         assert.strictEqual(string, "-11 520")
+    })
+    it("should return the number with prefix and rc style", () => {
+        const string = formatNumber(-11523, {
+            prefix: "$",
+            style: "rc",
+        })
+        assert.strictEqual(string, "$-11 523")
+    })
+    it("should return the number with suffix and rc style", () => {
+        const string = formatNumber(35.2, {
+            suffix: " C",
+            style: "rc",
+        })
+        assert.strictEqual(string, "35,2 C")
+    })
+    it("should return the number with a prefix, a suffix and rc style", () => {
+        const string = formatNumber(35.6, {
+            prefix: "Temp.: ",
+            suffix: " C",
+            style: "rc",
+        })
+        assert.strictEqual(string, "Temp.: 35,6 C")
     })
 })

--- a/test/format/formatNumber.test.ts
+++ b/test/format/formatNumber.test.ts
@@ -22,23 +22,120 @@ describe("formatNumber", () => {
         const string = formatNumber(1000000000.1234)
         assert.strictEqual(string, "1,000,000,000.1234")
     })
+    it("should return the number with + sign", () => {
+        const string = formatNumber(1.12, { sign: true })
+        assert.strictEqual(string, "+1.12")
+    })
+    it("should return the number with - sign", () => {
+        const string = formatNumber(-2.23, { sign: true })
+        assert.strictEqual(string, "-2.23")
+    })
+    it("should return the number rounded", () => {
+        const string = formatNumber(1.5345, { round: true })
+        assert.strictEqual(string, "2")
+    })
+    it("should return the number rounded with 2 decimals", () => {
+        const string = formatNumber(1.5345, { nbDecimals: 2 })
+        assert.strictEqual(string, "1.53")
+    })
+    it("should return the number rounded with base 10", () => {
+        const string = formatNumber(11523.5345, { nearestInteger: 10 })
+        assert.strictEqual(string, "11,520")
+    })
+    it("should return the number rounded with 2 decimals and + sign", () => {
+        const string = formatNumber(1.5345, { nbDecimals: 2, sign: true })
+        assert.strictEqual(string, "+1.53")
+    })
+    it("should return the number rounded with base 10 and + sign", () => {
+        const string = formatNumber(11523.5345, {
+            nearestInteger: 10,
+            sign: true,
+        })
+        assert.strictEqual(string, "+11,520")
+    })
+    it("should return the number rounded with 2 decimals and - sign", () => {
+        const string = formatNumber(-1.5345, { nbDecimals: 2, sign: true })
+        assert.strictEqual(string, "-1.53")
+    })
+    it("should return the number rounded with base 10 and - sign", () => {
+        const string = formatNumber(-11523.5345, {
+            nearestInteger: 10,
+            sign: true,
+        })
+        assert.strictEqual(string, "-11,520")
+    })
 
     // Radio-Canada style
 
     it("should return the number as a string without separator (using 1000)", () => {
-        const string = formatNumber(1000, "rc")
+        const string = formatNumber(1000, { style: "rc" })
         assert.strictEqual(string, "1000")
     })
     it("should return the number with non-breaking space as a thousand separator (using 10000)", () => {
-        const string = formatNumber(10000, "rc")
+        const string = formatNumber(10000, { style: "rc" })
         assert.strictEqual(string, "10 000")
     })
     it("should return the number with non-breaking space as a thousand separator (using 100000)", () => {
-        const string = formatNumber(100000, "rc")
+        const string = formatNumber(100000, { style: "rc" })
         assert.strictEqual(string, "100 000")
     })
     it("should return the number with non-breaking space as a thousand separator and keep decimals (using 1000000000.1234)", () => {
-        const string = formatNumber(1000000000.1234, "rc")
+        const string = formatNumber(1000000000.1234, { style: "rc" })
         assert.strictEqual(string, "1 000 000 000,1234")
+    })
+    it("should return the number with + sign with rc style", () => {
+        const string = formatNumber(1.12, { sign: true, style: "rc" })
+        assert.strictEqual(string, "+1,12")
+    })
+    it("should return the number with - sign with rc style", () => {
+        const string = formatNumber(-2.23, { sign: true, style: "rc" })
+        assert.strictEqual(string, "-2,23")
+    })
+    it("should return the number rounded with rc style", () => {
+        const string = formatNumber(1.5345, { round: true, style: "rc" })
+        assert.strictEqual(string, "2")
+    })
+    it("should return the number rounded with 2 decimals with rc style", () => {
+        const string = formatNumber(1.5345, { nbDecimals: 2, style: "rc" })
+        assert.strictEqual(string, "1,53")
+    })
+    it("should return the number rounded with base 10 with rc style", () => {
+        const string = formatNumber(11523.5345, {
+            nearestInteger: 10,
+            style: "rc",
+        })
+        assert.strictEqual(string, "11 520")
+    })
+    it("should return the number rounded with 2 decimals, + sign and rc style", () => {
+        const string = formatNumber(1.5345, {
+            nbDecimals: 2,
+            sign: true,
+            style: "rc",
+        })
+        assert.strictEqual(string, "+1,53")
+    })
+    it("should return the number rounded with base 10, + sign and rc style", () => {
+        const string = formatNumber(11523.5345, {
+            nearestInteger: 10,
+            sign: true,
+            style: "rc",
+        })
+        assert.strictEqual(string, "+11 520")
+    })
+    it("should return the number rounded with 2 decimals, - sign and rc style", () => {
+        const string = formatNumber(-1.5345, {
+            nbDecimals: 2,
+            sign: true,
+            style: "rc",
+        })
+        assert.strictEqual(string, "-1,53")
+    })
+    it("should return the number rounded with base 10, - sign and rc style", () => {
+        const string = formatNumber(-11523.5345, {
+            nearestInteger: 10,
+            sign: true,
+            style: "rc",
+        })
+        assert.strictEqual(string, "-11 520")
     })
 })


### PR DESCRIPTION
formatNumber has new options available:
- sign (boolean) to add a + sign if the number is positive
- round (boolean) to round the number before formatting it (using round function)
- nbDecimals (number) to round the number with a specific number of decimals (using round function)
- nearestInteger (number) to round the number on a specific base (10 for example, this is using the round function)
- prefix to add a string in front of a number ($ for example)
- suffix to add a string after the number (C for temperatures for example)