### PR TITLE
To fixed

### DIFF
--- a/src/format/formatNumber.ts
+++ b/src/format/formatNumber.ts
@@ -11,7 +11,8 @@ import round from "./round.js"
  * - style: "cbc" or "rc"
  * - sign: if true, "-" or "+" are added in front of the number
  * - round: to round the number
- * - decimals : the number of decimals to keep when rounding
+ * - decimals: the number of decimals to keep when rounding
+ * - fixed: display a fixed number of decimals. For example, if decimals is set to 2 then 0 will read 0.00.
  * - nearestInteger: the base to use to round. For example, 123 with the nearestInteger 10 is 120.
  * - prefix: a string to add before the number, "$" for example
  * - suffix: a string to add after the number, "%" for example
@@ -24,6 +25,7 @@ export default function formatNumber(
         sign?: boolean
         round?: boolean
         decimals?: number
+        fixed?:boolean
         nearestInteger?: number
         prefix?: string
         suffix?: string
@@ -38,6 +40,7 @@ export default function formatNumber(
         sign: boolean
         round: boolean
         decimals: number
+        fixed:boolean
         nearestInteger: number
         prefix: string
         suffix: string
@@ -46,6 +49,7 @@ export default function formatNumber(
         sign: false,
         round: false,
         decimals: 0,
+        fixed:false,
         nearestInteger: 1,
         prefix: "",
         suffix: "",
@@ -64,7 +68,7 @@ export default function formatNumber(
     }
 
     const regex = /\B(?=(\d{3})+(?!\d))/g
-    const [integers, decimals] = number.toString().split(".")
+    const [integers, decimals] = mergedOptions.fixed ? number.toFixed(mergedOptions.decimals).split(".") : number.toString().split(".")
 
     let formattedNumber = ""
 
@@ -76,7 +80,7 @@ export default function formatNumber(
             formattedNumber = formattedIntegers
         }
     } else if (mergedOptions.style === "rc") {
-        const string = number.toString()
+        const string = mergedOptions.fixed? number.toFixed(mergedOptions.decimals) : number.toString()
         if (string.length === 4) {
             formattedNumber = string.replace(".", ",")
         } else {

--- a/src/format/formatNumber.ts
+++ b/src/format/formatNumber.ts
@@ -25,7 +25,7 @@ export default function formatNumber(
         sign?: boolean
         round?: boolean
         decimals?: number
-        fixed?:boolean
+        fixed?: boolean
         nearestInteger?: number
         prefix?: string
         suffix?: string
@@ -40,7 +40,7 @@ export default function formatNumber(
         sign: boolean
         round: boolean
         decimals: number
-        fixed:boolean
+        fixed: boolean
         nearestInteger: number
         prefix: string
         suffix: string
@@ -49,7 +49,7 @@ export default function formatNumber(
         sign: false,
         round: false,
         decimals: 0,
-        fixed:false,
+        fixed: false,
         nearestInteger: 1,
         prefix: "",
         suffix: "",
@@ -68,7 +68,9 @@ export default function formatNumber(
     }
 
     const regex = /\B(?=(\d{3})+(?!\d))/g
-    const [integers, decimals] = mergedOptions.fixed ? number.toFixed(mergedOptions.decimals).split(".") : number.toString().split(".")
+    const [integers, decimals] = mergedOptions.fixed
+        ? number.toFixed(mergedOptions.decimals).split(".")
+        : number.toString().split(".")
 
     let formattedNumber = ""
 
@@ -80,7 +82,9 @@ export default function formatNumber(
             formattedNumber = formattedIntegers
         }
     } else if (mergedOptions.style === "rc") {
-        const string = mergedOptions.fixed? number.toFixed(mergedOptions.decimals) : number.toString()
+        const string = mergedOptions.fixed
+            ? number.toFixed(mergedOptions.decimals)
+            : number.toString()
         if (string.length === 4) {
             formattedNumber = string.replace(".", ",")
         } else {

--- a/test/format/formatNumber.test.ts
+++ b/test/format/formatNumber.test.ts
@@ -153,7 +153,7 @@ describe("formatNumber", () => {
         })
         assert.strictEqual(string, "+1,53")
     })
-    it("should return the number rounded, with 2 fixed decimals, +sign and rx style", () => {
+    it("should return the number rounded, with 2 fixed decimals, +sign and rc style", () => {
         const string = formatNumber(1.2, {
             decimals: 2,
             fixed: true,

--- a/test/format/formatNumber.test.ts
+++ b/test/format/formatNumber.test.ts
@@ -38,6 +38,10 @@ describe("formatNumber", () => {
         const string = formatNumber(1.5345, { decimals: 2 })
         assert.strictEqual(string, "1.53")
     })
+    it("should return the number rounded with 2 fixed decimals", () => {
+        const string = formatNumber(1.5042, { decimals: 2, fixed: true })
+        assert.strictEqual(string, "1.50")
+    })
     it("should return the number rounded with base 10", () => {
         const string = formatNumber(11523.5345, { nearestInteger: 10 })
         assert.strictEqual(string, "11,520")
@@ -125,6 +129,14 @@ describe("formatNumber", () => {
     it("should return the number rounded with 2 decimals with rc style", () => {
         const string = formatNumber(1.5345, { decimals: 2, style: "rc" })
         assert.strictEqual(string, "1,53")
+    })
+    it("should return the number rounded with 2 fixed decimals with rc style", () => {
+        const string = formatNumber(1.5042, {
+            decimals: 2,
+            fixed: true,
+            style: "rc",
+        })
+        assert.strictEqual(string, "1,50")
     })
     it("should return the number rounded with base 10 with rc style", () => {
         const string = formatNumber(11523.5345, {

--- a/test/format/formatNumber.test.ts
+++ b/test/format/formatNumber.test.ts
@@ -57,6 +57,14 @@ describe("formatNumber", () => {
         const string = formatNumber(-1.5345, { decimals: 2, sign: true })
         assert.strictEqual(string, "-1.53")
     })
+    it("should return the number rounded with 2 fixed decimals and - sign", () => {
+        const string = formatNumber(-1.5023, {
+            decimals: 2,
+            fixed: true,
+            sign: true,
+        })
+        assert.strictEqual(string, "-1.50")
+    })
     it("should return the number rounded with base 10 and - sign", () => {
         const string = formatNumber(-11523.5345, {
             nearestInteger: 10,
@@ -132,6 +140,15 @@ describe("formatNumber", () => {
             style: "rc",
         })
         assert.strictEqual(string, "+1,53")
+    })
+    it("should return the number rounded, with 2 fixed decimals, +sign and rx style", () => {
+        const string = formatNumber(1.2, {
+            decimals: 2,
+            fixed: true,
+            sign: true,
+            style: "rc",
+        })
+        assert.strictEqual(string, "+1,20")
     })
     it("should return the number rounded with base 10, + sign and rc style", () => {
         const string = formatNumber(11523.5345, {


### PR DESCRIPTION
The purpose of this PR is to add a toFixed option to the numberFormatter. Currently, there is not an easy way to display a fixed number of decimals, i.e. trailing zeros. This change allows users to toggle toFixed, using the number of decimals specified in the decimals option. Tests are written and passing for this feature.